### PR TITLE
Check if running live to avoid pacstrab -c

### DIFF
--- a/bin/base.install
+++ b/bin/base.install
@@ -26,7 +26,14 @@ fi
 SYSTEM_NAME=$1
 MOUNT_POINT=$2
 
-pacstrap -c $MOUNT_POINT base linux linux-lts linux-firmware
+# Check if we are running from live usb/iso to avoid '-c' (See man pacstrap)
+fs=$(basename `df / | tail -1 | awk '{ print $1; }'`)
+if grep -q "$fs" /proc/partitions; then
+  pacstrap -c $MOUNT_POINT base linux linux-lts linux-firmware
+else
+  pacstrap $MOUNT_POINT base linux linux-lts linux-firmware
+fi
+
 genfstab -U $MOUNT_POINT >> $MOUNT_POINT/etc/fstab
 arch-chroot $MOUNT_POINT ln -sf /usr/share/zoneinfo/Europe/Berlin /etc/localtime
 arch-chroot $MOUNT_POINT hwclock --systohc


### PR DESCRIPTION
When running in live usb/iso there is not enough space for storing the cache locally to run pacstrab -c.